### PR TITLE
Add service_ensure and service_enable parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-##2016-10-24 - qivers 0.4.0
+## 2016-10-24 - qivers 0.4.0
   * Added Debian-specific service support
 
-##2016-07-16 - Shawn Sterling <shawn@systemtemplar.org> 0.3.0
+## 2016-07-16 - Shawn Sterling <shawn@systemtemplar.org> 0.3.0
  * Moved OS specifics into the params
  * Added Amazon, RedHat, Debian, OracleLinux, Scientific support
  * Added ability to use custom_url for downloading the package
  * Added ability to use custom_path for saving the package to
  * Added lint ignores
 
-##2016-06-24 - Todd Courtnage <todd@courtnage.ca> 0.2.0
+## 2016-06-24 - Todd Courtnage <todd@courtnage.ca> 0.2.0
  * CentOS support (Thanks @chroto)
 
-##2016-02-09 - Todd Courtnage <todd@courtnage.ca> 0.1.0
+## 2016-02-09 - Todd Courtnage <todd@courtnage.ca> 0.1.0
  * First pulic release

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,34 +1,69 @@
-# Class: ssm
-# ===========================
+# == Class: ssm
 #
 # Downloads and installs the amazon-ssm-agent, i.e. the EC2 run command agent
 #
-# Parameters
-# ----------
+# == Parameters
 #
-# * `region`
-# The region to download the agent in. Default is undef.
+# [*custom_path*]
+#   String indicating the location where the package will be downloaded. If the
+#   path specified is not present, the module will create it.
+#   Defaults to `/opt/amazon-ssm-agent.${package}`.
 #
-# Examples
-# --------
+# [*custom_url*]
+#   String indicating the URL to use when downloading the SSM package.
+#   Defaults to the standard URL for the AWS region specified in `ssm::region`.
+#
+# [*flavor*]
+#   String specifying the OS flavor. This is used when building the default
+#   download URL. The correct value is automatically set based on the platform.
+#
+# [*manage_service*]
+#   Bool. If set, the module will manage the SSM service. Defaults to `true`.
+#
+# [*package*]
+#   String representing the package type. The correct type, either `rpm` or
+#   `deb`, is automatically set based on the platform.
+#
+# [*provider*]
+#   String indicating the type of package provider to use when installing the
+#   SSM agent. The correct type, either `rpm` or `dpkg`, is automatically set
+#   based on the platform.
+#
+# [*region*]
+#   String indicating the AWS region in which the instance is running. Required.
+#   Defaults to `undef`.
+#
+# [*service_enable*]
+#   Bool. If set, the module will ensure the SSM service is enabled and
+#   automatically started by the service manager. Only valid when
+#   `manage_service` is `true`. Defaults to `true`.
+#
+# [*service_ensure*]
+#   String indicating the desired state of the SSM service. Only valid when
+#   `manage_service` is `true`. Defaults to `running`.
+#
+# [*service_name*]
+#   String indicating the name of the SSM service. The correct value is
+#   automatically determined based on the platform.
+#
+# == Examples
 #
 # @example
 #    class { 'ssm':
 #      region => 'us-east-1',
 #    }
 #
-# Authors
-# -------
+# == Authors
 #
 # Todd Courtnage <todd@courtnage.ca>
 # Shawn Sterling <shawn@systemtemplar.org>
 #
-# Copyright
-# ---------
+# == Copyright
 #
 # Copyright 2016 Todd Courtnage
 #
 # lint:ignore:80chars
+#
 class ssm (
   $custom_path    = $ssm::params::custom_path,
   $custom_url     = $ssm::params::custom_url,
@@ -37,6 +72,8 @@ class ssm (
   $package        = $ssm::params::package,
   $provider       = $ssm::params::provider,
   $region         = $ssm::params::region,
+  $service_enable = $ssm::params::service_enable,
+  $service_ensure = $ssm::params::service_ensure,
   $service_name   = $ssm::params::service_name,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
@@ -76,6 +113,8 @@ class ssm (
 
   class { 'ssm::service':
     manage_service => $manage_service,
+    service_enable => $service_enable,
+    service_ensure => $service_ensure,
     service_name   => $service_name,
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,23 @@
-# Install the ssm package
+# == Class ssm::install
+#
+# This class is called from ssm::init to install the SSM package.
+#
+# == Parameters
+#
+# [*path*]
+#   Specifies the location where the package will be downloaded. The path can
+#   be set using `ssm::custom_path` othwerwise, the correct default path is
+#   generated in ssm::init.
+#
+# [*provider*]
+#  Specifies the provider type to use when installing the package. The correct
+#  provider is determined automatically based on platform in ssm::params.
+#
+# [*url*]
+#   String indicating the URL to use when downloading the SSM package. The URL
+#   can be set using `ssm::custom_url` otherwise, the correct default URL is
+#   generated in ssm::init.
+#
 class ssm::install(
   $path     = undef,
   $provider = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,9 +1,15 @@
-# Params
+# == Class ssm::params
+#
+# This class is called from ssm::init to set variable defaults.
+#
 class ssm::params {
   $custom_path    = false
   $custom_url     = false
   $manage_service = true
   $region         = undef
+  $service_enable = true
+  $service_ensure = 'running'
+
   case $::operatingsystem {
     'Amazon', 'CentOS', 'OracleLinux', 'RedHat', 'Scientific': {
       $service_name = 'amazon-ssm-agent'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,29 @@
-# Ensure ssm service is running.
+# == Class ssm::service
+#
+# This class is called from ssm::init to ensure the SSM service is running.
+#
+# == Parameters
+#
+# [*manage_service*]
+#   Bool. If set, puppet will manage the SSM service. Defaults to `true`.
+#
+# [*service_enable*]
+#   Bool. If set, the module will ensure the SSM service is enabled and
+#   automatically started by the service manager. Only valid when
+#   `manage_service` is `true`. Defaults to `true`.
+#
+# [*service_ensure*]
+#   String indicating the desired state of the SSM service. Only valid when
+#   `manage_service` is `true`. Defaults to `running`.
+#
+# [*service_name*]
+#   String indicating the name of the SSM service. The correct value is
+#   automatically determined based on the platform.
+#
 class ssm::service(
   $manage_service = $ssm::params::manage_service,
+  $service_enable = $ssm::params::service_enable,
+  $service_ensure = $ssm::params::service_ensure,
   $service_name   = $ssm::params::manage_service,
 ) inherits ssm::params { # lint:ignore:class_inherits_from_params_class
 
@@ -8,14 +31,16 @@ class ssm::service(
     case $::operatingsystem {
       'Debian': {
         service { $service_name:
-          ensure     => running,
-          subscribe  => Package['amazon-ssm-agent'],
-          require    => Class['ssm::install'],
+          ensure    => $service_ensure,
+          enable    => $service_enable,
+          subscribe => Package['amazon-ssm-agent'],
+          require   => Class['ssm::install'],
         }
       }
       default: {
         service { $service_name:
-          ensure     => running,
+          ensure     => $service_ensure,
+          enable     => $service_enable,
           hasstatus  => true,
           hasrestart => true,
           restart    => "/sbin/restart ${service_name}",


### PR DESCRIPTION
Previously, the module would ensure the SSM service was running but would not set the service to enabled. This change introduces two new parameters that permits the user to control the desired state and whether the service should be enabled:
- `$ssm::params::service_enable`; defaults to `true`
- `$ssm::params::service_ensure`; defaults to `running`

I also took the liberty of adding documentation headers to all classes, documented all new and existing parameters and fixed some formatting issues in the CHANGELOG. 

Thanks for the great module and hope these changes find you well!

