### PR TITLE
added centos operatingsystem case in service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -45,6 +45,14 @@ class ssm::service(
           require   => Class['ssm::install'],
         }
       }
+      'CentOS': {
+        service { $service_name:
+          ensure    => $service_ensure,
+          enable    => $service_enable,
+          subscribe => Package['amazon-ssm-agent'],
+          require   => Class['ssm::install'],
+        }
+      }
       default: {
         service { $service_name:
           ensure     => $service_ensure,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -53,6 +53,19 @@ class ssm::service(
           require   => Class['ssm::install'],
         }
       }
+      'Amazon': {
+        service { $service_name:
+          ensure    => $service_ensure,
+          hasstatus  => true,
+          hasrestart => true,
+          restart    => "/sbin/restart ${service_name}",
+          start      => "/sbin/start ${service_name}",
+          status     => "/sbin/status ${service_name}",
+          stop       => "/sbin/stop ${service_name}",
+          subscribe => Package['amazon-ssm-agent'],
+          require   => Class['ssm::install'],
+        }
+      }
       default: {
         service { $service_name:
           ensure     => $service_ensure,


### PR DESCRIPTION
The default case results in a false failure when starting the service, so added a case for CentOS similar to Ubuntu and Debian.

Tested successfully with CentOS7