### PR TITLE
Use upstart provider for Amazon Linux

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -58,10 +58,7 @@ class ssm::service(
           ensure    => $service_ensure,
           hasstatus  => true,
           hasrestart => true,
-          restart    => "/sbin/restart ${service_name}",
-          start      => "/sbin/start ${service_name}",
-          status     => "/sbin/status ${service_name}",
-          stop       => "/sbin/stop ${service_name}",
+          provider  => 'upstart',
           subscribe => Package['amazon-ssm-agent'],
           require   => Class['ssm::install'],
         }


### PR DESCRIPTION
If the service is already in a stopped state, and you initialize the ssm module with `service_ensure => stopped`, an error is encountered by Puppet. 

The upstart provider should be used as this has logic built in to detect the status of a job.

Before change:
```
Notice: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]/ensure: created
Info: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Scheduling refresh of Service[amazon-ssm-agent]
Debug: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: The container Class[Ssm::Install] will propagate my refresh event
Notice: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Scheduling refresh of Service[amazon-ssm-agent]
Debug: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: The container Class[Ssm::Install] will propagate my refresh event
Debug: Class[Ssm::Install]: The container Stage[main] will propagate my refresh event
Debug: Executing: '/sbin/status amazon-ssm-agent'
Debug: Executing: '/sbin/stop amazon-ssm-agent'
Notice: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]/ensure: ensure changed 'running' to 'stopped'
Debug: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: The container Class[Ssm::Service] will propagate my refresh event
Debug: Executing: '/sbin/status amazon-ssm-agent'
Debug: Executing: '/sbin/restart amazon-ssm-agent'
Error: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: Failed to call refresh: Could not restart Service[amazon-ssm-agent]: Execution of '/sbin/restart amazon-ssm-agent' returned 1: restart: Unknown instance:
Error: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: Could not restart Service[amazon-ssm-agent]: Execution of '/sbin/restart amazon-ssm-agent' returned 1: restart: Unknown instance:
```

After change:
```
Notice: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]/ensure: created
Info: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Scheduling refresh of Service[amazon-ssm-agent]
Debug: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: The container Class[Ssm::Install] will propagate my refresh event
Notice: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Triggered 'refresh' from 1 events
Info: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: Scheduling refresh of Service[amazon-ssm-agent]
Debug: /Stage[main]/Ssm::Install/Package[amazon-ssm-agent]: The container Class[Ssm::Install] will propagate my refresh event
Debug: Class[Ssm::Install]: The container Stage[main] will propagate my refresh event
Debug: Executing: '/sbin/status amazon-ssm-agent'
Debug: Executing: '/sbin/stop amazon-ssm-agent'
Notice: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]/ensure: ensure changed 'running' to 'stopped'
Debug: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: The container Class[Ssm::Service] will propagate my refresh event
Debug: Executing: '/sbin/status amazon-ssm-agent'
Debug: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: Skipping restart; service is not running
Notice: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: Triggered 'refresh' from 2 events
Debug: /Stage[main]/Ssm::Service/Service[amazon-ssm-agent]: The container Class[Ssm::Service] will propagate my refresh event
```